### PR TITLE
fix(v2): stop auto-tour from re-firing on every page load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,15 @@ What happens automatically:
 
 Do both #1 and #2 in the same PR. They're independent entries in `TOURS`, and the per-step seen map is keyed by `tourId` so they don't interfere.
 
+### Close vs complete
+
+Both close (X button) and complete ("Got it" on the last step) write to the seen map, but they write **different things**:
+
+- **Complete**: marks just the steps shown in this run. For a delta run (returning user with new steps), that's only the new ones — the rest were already in seen.
+- **Close**: marks **all current step ids** for the tour, regardless of how many were shown. This is the "I dismissed this tour, stop nagging me on every reload" signal. Autostart only fires when there are unseen steps in the tour definition, so once everything is marked seen via close, future page loads won't auto-trigger. Adding **new** step ids to the tour later still triggers autostart for those — exactly the behaviour we want.
+
+Don't change close to "mark only what was viewed" — that re-introduces the bug where closing on step 1 left steps 2–N unseen, and the autostart re-fired on every reload until the user clicked through every step. Mixpanel caught this with three `Tour Start` events in 30 seconds for the same `distinct_id`. Locked in by `tests/v2/intro-tour.spec.ts:closing mid-tour marks all current step ids so the auto-tour does not re-fire`.
+
 ### Forcing a re-see after a major rewrite
 
 Two options if you rewrite an existing step's copy and want everyone to see it again:

--- a/app/v2/components/Tour.tsx
+++ b/app/v2/components/Tour.tsx
@@ -105,9 +105,25 @@ export function startTour(id: string, opts?: StartOptions): void {
 export function Tour() {
   const { t, dir } = useAppContext();
   const activeDriverRef = useRef<Driver | null>(null);
+  const isCleanupDestroyRef = useRef(false);
+  // Keep refs to the latest t/dir so the mount-once effect closure can
+  // read current values without itself depending on them. Tying the
+  // effect to [t, dir] (or to the AppContext value) caused it to re-run
+  // on context updates, which destroyed any in-progress driver and
+  // re-fired autostart — manifesting as duplicate Tour Start events
+  // and tours that vanished mid-step.
+  const tRef = useRef(t);
+  const dirRef = useRef(dir);
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+  useEffect(() => {
+    dirRef.current = dir;
+  }, [dir]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
+    isCleanupDestroyRef.current = false;
 
     const resolveSteps = (tourId: string, replay: boolean): TourStep[] => {
       const tour = findTour(tourId);
@@ -117,7 +133,12 @@ export function Tour() {
       return pool.filter((s) => !s.element || document.querySelector(s.element) != null);
     };
 
-    const run = (tourId: string, trigger: "first-visit" | "manual", replay: boolean) => {
+    const run = (tourId: string, trigger: "auto" | "manual", replay: boolean) => {
+      // Read latest t/dir at run time — the effect mounts once but t/dir
+      // change as the user picks a different language.
+      const t = tRef.current;
+      const dir = dirRef.current;
+
       activeDriverRef.current?.destroy();
 
       const tour = findTour(tourId);
@@ -161,9 +182,28 @@ export function Tour() {
           });
         },
         onDestroyStarted: () => {
+          if (isCleanupDestroyRef.current) {
+            // React-driven destroy (effect cleanup, unmount). Don't touch
+            // the seen map — the user didn't explicitly dismiss the tour.
+            d.destroy();
+            return;
+          }
           const activeIndex = d.getActiveIndex();
           const completed = activeIndex != null && activeIndex >= totalShown - 1;
-          const seenNow = activeIndex != null ? shownStepIds.slice(0, activeIndex + 1) : [];
+
+          // On complete: just record what was actually shown — for delta runs
+          // that's only the new steps; the rest were already seen.
+          // On close (mid-tour dismiss): mark ALL current step ids as seen so
+          // the auto-tour doesn't re-fire on every page load until the user
+          // happens to click through everything. The contextual `?` icon is
+          // always there if they want to come back. Adding NEW steps to the
+          // tour later still triggers autostart because those new ids won't
+          // be in the seen set yet.
+          const seenNow = completed
+            ? activeIndex != null
+              ? shownStepIds.slice(0, activeIndex + 1)
+              : []
+            : tour.steps.map((s) => s.id);
           markStepsSeen(tourId, seenNow);
 
           const payload = {
@@ -216,16 +256,19 @@ export function Tour() {
     });
     let timer: number | null = null;
     if (autoTour) {
-      timer = window.setTimeout(() => run(autoTour.id, "first-visit", false), 600);
+      timer = window.setTimeout(() => run(autoTour.id, "auto", false), 600);
     }
 
     return () => {
       if (timer != null) window.clearTimeout(timer);
       window.removeEventListener(TOUR_START_EVENT, handler);
       (window as WindowWithReadyFlag)[TOUR_READY_FLAG] = false;
+      isCleanupDestroyRef.current = true;
       activeDriverRef.current?.destroy();
     };
-  }, [t, dir]);
+    // Mount-once: latest t/dir are read via tRef/dirRef inside `run`.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return null;
 }

--- a/tests/mock-calculator.ts
+++ b/tests/mock-calculator.ts
@@ -13,22 +13,22 @@ type CalculatorItem =
   | { type: "simple"; id: "ss" | "ws" | "se" | "ae"; time: string };
 
 function fixtureFor(year: number): CalculatorItem[] {
-  return [
-    // Full moon in Jan
-    { type: "mphase", id: "fm", time: `${year}-01-14T04:27:00Z`, pos: 0 },
-    // New moon in Jan
-    { type: "mphase", id: "nm", time: `${year}-01-29T12:36:00Z`, pos: 0 },
-    // Full moon in April (the "current" month for most tests)
-    { type: "mphase", id: "fm", time: `${year}-04-12T02:22:00Z`, pos: 0 },
-    // New moon in April
-    { type: "mphase", id: "nm", time: `${year}-04-26T17:31:00Z`, pos: 0 },
-    // Vernal equinox
-    { type: "simple", id: "ae", time: `${year}-03-20T04:45:00Z` },
-    // Summer solstice
-    { type: "simple", id: "ss", time: `${year}-06-21T02:11:00Z` },
-    // Solar eclipse
-    { type: "eclipse", id: "se", planet: "sun", time: `${year}-08-12T10:43:00Z`, pos: 0 },
-  ];
+  // One full moon + one new moon for every month so the v2 page always
+  // renders the events grid regardless of which month "today" lands in
+  // — without that, the intro tour's `events` step gets filtered out
+  // (no [data-tour="events"] anchor), the tour shrinks by one step, and
+  // any test that loops INTRO_STEPS.length - 1 times mis-counts.
+  const items: CalculatorItem[] = [];
+  for (let month = 1; month <= 12; month++) {
+    const mm = String(month).padStart(2, "0");
+    items.push({ type: "mphase", id: "fm", time: `${year}-${mm}-12T02:22:00Z`, pos: 0 });
+    items.push({ type: "mphase", id: "nm", time: `${year}-${mm}-26T17:31:00Z`, pos: 0 });
+  }
+  // Plus a couple of seasonal markers + an eclipse for variety.
+  items.push({ type: "simple", id: "ae", time: `${year}-03-20T04:45:00Z` });
+  items.push({ type: "simple", id: "ss", time: `${year}-06-21T02:11:00Z` });
+  items.push({ type: "eclipse", id: "se", planet: "sun", time: `${year}-08-12T10:43:00Z`, pos: 0 });
+  return items;
 }
 
 export function startMockCalculator(port: number): Promise<Server> {

--- a/tests/v2/intro-tour.spec.ts
+++ b/tests/v2/intro-tour.spec.ts
@@ -53,18 +53,28 @@ test.describe("intro tour", () => {
     expect(await tourTitle(page)).toContain("Welcome to Astro Events");
   });
 
-  test("closing mid-tour marks only the steps shown so far", async ({ page }) => {
+  test("closing mid-tour marks all current step ids so the auto-tour does not re-fire", async ({
+    page,
+  }) => {
+    // This was a real production bug: closing on step 1 only marked step 1
+    // as seen, so on the next page load the runner saw 6 unseen steps and
+    // auto-started again. Mixpanel showed users hitting Tour Start three
+    // times in 30 seconds. Closing must signal "I'm done with this tour"
+    // — autostart should not re-nag. Replay via the footer ? still works.
     await page.goto("/v2");
     await waitForTourPopover(page);
 
-    // Advance past welcome → theme → language, then close via the X button.
-    await page.getByRole("button", { name: "Next", exact: true }).click(); // → theme
-    await page.getByRole("button", { name: "Next", exact: true }).click(); // → language
+    // Close immediately on step 1 (welcome).
     await page.locator(".driver-popover-close-btn").click();
-
     await expect(page.locator(".driver-popover.v2-tour-popover")).toHaveCount(0);
+
     const seen = await readSeen(page);
-    expect(seen.intro).toEqual(["welcome", "theme", "language"]);
+    expect(new Set(seen.intro)).toEqual(new Set(INTRO_STEPS));
+
+    // Reload — autostart must NOT fire because everything is marked seen.
+    await page.reload();
+    await page.waitForTimeout(900);
+    await expect(page.locator(".driver-popover.v2-tour-popover")).toHaveCount(0);
   });
 
   test("clicking the backdrop does not close the tour", async ({ page }) => {

--- a/tests/v2/navigation.spec.ts
+++ b/tests/v2/navigation.spec.ts
@@ -15,19 +15,22 @@ test.describe("month navigation", () => {
   });
 
   test("prev/next buttons update the URL and rendered month label", async ({ page }) => {
-    await page.goto("/v2?year=2026&month=6");
+    // Use a year safely far from "now" so navigating doesn't accidentally
+    // land on the current month — Navigation.tsx strips ?year/&month from
+    // the URL when the target IS the current month, which would make the
+    // toHaveURL assertion fail in May 2030.
+    await page.goto("/v2?year=2030&month=6");
 
-    // June 2026 rendered.
-    await expect(page.getByText(/June 2026/i)).toBeVisible();
+    await expect(page.getByText(/June 2030/i)).toBeVisible();
 
     await page.getByRole("button", { name: "Next month" }).click();
-    await expect(page).toHaveURL(/year=2026&month=7/);
-    await expect(page.getByText(/July 2026/i)).toBeVisible();
+    await expect(page).toHaveURL(/year=2030&month=7/);
+    await expect(page.getByText(/July 2030/i)).toBeVisible();
 
     await page.getByRole("button", { name: "Previous month" }).click();
     await page.getByRole("button", { name: "Previous month" }).click();
-    await expect(page).toHaveURL(/year=2026&month=5/);
-    await expect(page.getByText(/May 2026/i)).toBeVisible();
+    await expect(page).toHaveURL(/year=2030&month=5/);
+    await expect(page.getByText(/May 2030/i)).toBeVisible();
   });
 
   test("today button jumps back to the current month and drops URL params", async ({ page }) => {


### PR DESCRIPTION
## Summary

Production bug: a returning user who closed the intro tour mid-walkthrough kept hitting it on every page load. Mixpanel showed three `Tour Start` events for the same `distinct_id` within 30 seconds — autostart fired, user closed after step 1, only step 1 was marked seen, the next page load saw 6 unseen steps and fired again, repeat.

Four fixes in `app/v2/components/Tour.tsx`:

1. **Close marks all current step ids as seen** — closing is an explicit "I'm done with this tour" signal; autostart should not re-nag. Adding NEW step ids to the tour later still triggers autostart because those new ids won't be in the seen set, so the delta-replay UX still works.
2. **Cleanup-driven destroys skip the close-marks-all logic** — without this, anything that re-rendered Tour mid-tour (e.g. a context value change) would poison the seen map. Surfaced by parallel Playwright runs.
3. **Mount-once effect** — read latest `t`/`dir` via refs inside `run`. Tying the effect to `[t, dir]` caused it to re-run on context updates which destroyed any in-progress driver and re-fired autostart.
4. **Mixpanel `trigger: "first-visit"` → `"auto"`** — original name was misleading; it fires whenever the auto-tour has unseen steps, not literally on first visit.

## Other fixes pulled in

- `tests/v2/intro-tour.spec.ts` — rewrote the "closing mid-tour" test to assert all current step ids are seen AND a reload doesn't re-fire the tour. This is the regression guard for the production bug.
- `tests/mock-calculator.ts` — emit a full moon + new moon for every month so the v2 page always has events to render. Without this the events grid was missing in months we forgot to seed (e.g. May), the `[data-tour="events"]` anchor didn't exist, the intro tour's events step got filtered out, and any test that loops a fixed step count miscounts. Today is May 2026; this test only started failing now.
- `tests/v2/navigation.spec.ts` — switched the test fixture year to 2030 to avoid landing on the current month, where `Navigation.tsx` strips `?year/&month` from the URL.
- `CLAUDE.md` — new "Close vs complete" section explaining the semantics so the next contributor doesn't revert the close-marks-all behaviour.

## Test plan

- [x] `yarn test:e2e` — 20 tests pass; ran 3 consecutive times for stability
- [x] `npx tsc --noEmit` clean
- [x] Manual verification at `/v2`:
  - [x] Clear localStorage → intro tour autoruns. Close on step 1 → reload → no re-fire.
  - [x] Replay via footer `?` still works.
  - [ ] In dev tools, append a new fake step id to the intro tour locally, reload → autostart fires for just the new step (delta UX still intact).
- [ ] After merge, watch mixpanel: `Tour Start` count per `distinct_id` should drop dramatically.

## Note on the branch base

The branch is forked from the tip of `feat/v2-guided-tour` (PR #582), since `main` doesn't have the tour code yet. The diff vs `main` therefore includes everything from #582 plus this fix. Once this PR is approved/merged to main, close #582 (or merge them in either order — same end state).