### PR TITLE
Self-host on PVE: containerize (standalone) + Docker/Traefik deploy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,22 @@
+# Keep the build context small + NEVER bake secrets/source into the image.
+node_modules
+.next
+.git
+.github
+.gitignore
+.dockerignore
+Dockerfile
+# secrets — runtime-injected on the host, never in the image:
+.env
+.env.*
+*.log
+.claude
+.vscode
+tests
+e2e
+playwright.config.*
+playwright-report
+test-results
+coverage
+README*
+tsconfig.tsbuildinfo

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,48 @@
+name: Build & publish astro image
+
+# PUBLIC-REPO SAFE: only builds + pushes the image to GHCR (all on GitHub-hosted
+# runners). Deployment is done by a pull-agent on LXC 106 — GitHub never executes
+# anything on the home network.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-astro
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write   # push image to GHCR
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest           # GitHub-hosted (free + unlimited for public repos)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # NO deploy job here — deploy is decoupled for maximum security on a public repo:
+  # a pull-agent on LXC 106 (systemd timer) watches GHCR and runs
+  # `docker compose pull && docker rollout` itself. GitHub has zero execution
+  # foothold on the home network (no self-hosted runner, no inbound, no token).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# syntax=docker/dockerfile:1
+
+# ---- deps: install dependencies (cached on lockfile) ----
+FROM node:26-alpine AS deps
+WORKDIR /app
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# ---- builder: standalone Next.js build ----
+FROM node:26-alpine AS builder
+WORKDIR /app
+ARG GIT_SHA=dev
+# BUILD_STANDALONE=1 makes next.config emit output:'standalone' (Netlify stays default).
+ENV BUILD_STANDALONE=1 \
+    NEXT_PUBLIC_BUILD_ID=$GIT_SHA \
+    NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN yarn build
+
+# ---- runner: minimal runtime (no build tools, no source) ----
+FROM node:26-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    HOSTNAME=0.0.0.0 \
+    PORT=3000
+RUN addgroup -g 1001 -S nodejs && adduser -S nextjs -u 1001
+# Standalone server + the assets it does NOT bundle automatically:
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+USER nextjs
+EXPOSE 3000
+# '/' is SSR from local data → reliable health signal (independent of the external v2 API).
+HEALTHCHECK --interval=10s --timeout=5s --start-period=25s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1
+CMD ["node", "server.js"]

--- a/app/(index)/page.tsx
+++ b/app/(index)/page.tsx
@@ -1,20 +1,25 @@
-import { headers } from "next/headers";
-
 import type { EventBaseType } from "../../types/events";
 import type { SearchParams } from "../../types/searchParams";
 
 import { getDateFromSearchParams } from "../../utils/date";
 
+import eventsData from "../../data/events";
 import IndexPage from "./components/IndexPage";
 
-const protocol = process.env.NODE_ENV === "development" ? "http" : "https";
+// Read the local events data directly in the server component instead of doing a
+// server-side self-fetch to /api/events. The self-fetch broke under `output:
+// 'standalone'` (NODE_ENV=production forced https against an http server) and would
+// also hairpin through Cloudflare in the container. Same filter as the route handler.
+function getEventsForMonth(events: EventBaseType[], date: Date): EventBaseType[] {
+  const year = date.getFullYear();
+  const month = date.getUTCMonth();
 
-async function getEvents(dateISO: string) {
-  const host = (await headers()).get("host");
-  const res = await fetch(`${protocol}://${host}/api/events?date=${dateISO}`);
-
-  if (!res.ok) throw new Error("Failed to fetch events");
-  return res.json();
+  return events
+    .filter((event) => {
+      const eventDate = new Date(event.startDate);
+      return eventDate.getFullYear() === year && eventDate.getUTCMonth() === month;
+    })
+    .sort((a, b) => (a.startDate > b.startDate ? 1 : -1));
 }
 
 type PageProps = {
@@ -22,15 +27,14 @@ type PageProps = {
 };
 
 export default async function Page(props: PageProps) {
+  const searchParams = await props.searchParams;
+  const date = getDateFromSearchParams(searchParams);
+
   let events: EventBaseType[] = [];
   let error = false;
 
-  const searchParams = await props.searchParams;
-  const date = getDateFromSearchParams(searchParams);
-  const dateISO = date.toISOString().split("T")[0];
-
   try {
-    events = await getEvents(dateISO);
+    events = getEventsForMonth(eventsData, date);
   } catch {
     error = true;
   }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from 'next'
+
+const nextConfig: NextConfig = {
+  // 'standalone' produces a minimal self-hosted server build (used for our Docker image).
+  // Gated on BUILD_STANDALONE=1 (set only in the Docker/CI build) so Netlify deploy
+  // previews keep their default output and are unaffected.
+  ...(process.env.BUILD_STANDALONE === '1' ? { output: 'standalone' as const } : {}),
+}
+
+export default nextConfig

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "dependencyDashboard": true,
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## What
Containerize the app to self-host on the home Proxmox box (Docker + Traefik behind a Cloudflare Tunnel), deployed automatically on merge to `main`. **Netlify is kept for deploy previews only.**

## Changes
- **next.config.ts** — `output: 'standalone'` gated on `BUILD_STANDALONE=1` (only our Docker build emits it; Netlify keeps its default output).
- **Dockerfile** — multi-stage standalone build on `node:26-alpine`, copies `.next/standalone` + `.next/static` + `public`, runs **non-root** (`nextjs`), `HEALTHCHECK` on `/`, injects `GIT_SHA`→`NEXT_PUBLIC_BUILD_ID`.
- **.dockerignore** — keeps `.env*`, source and `node_modules` out of the image (no secrets baked in).
- **app/(index)/page.tsx** — read `data/events` **directly** instead of a server-side self-fetch to `/api/events`. The self-fetch (`https://${host}/api/events` in prod) broke under `output: 'standalone'` (https against an http server) and would hairpin through Cloudflare in the container. Month nav is URL-driven (`<Link>`); `/api/events` and `/api/calendar` are untouched (the latter is the public iCal feed).
- **.github/workflows/deploy.yml** — builds + pushes the image to **GHCR** on push to `main` (GitHub-hosted runners). **Deploy is decoupled**: a pull-agent on the PVE host watches GHCR and runs `docker rollout` (zero-downtime via Traefik). No self-hosted runner → GitHub has no execution foothold on the home network (safest for a public repo).
- **renovate.json** — adds `minimumReleaseAge: "7 days"` + `internalChecksFilter: strict` (supply-chain cooldown: freshly published/compromised versions aren't pulled immediately); `config:base` → `config:recommended`.

## Runtime notes (not in this repo)
- Runtime secrets (`CALCULATOR_API_URL`, `CALCULATOR_API_KEY`, `LIBRE_TRANSLATE_URL`) are injected on the host at runtime (`/opt/astro/.env`), never in the image or repo.
- After merge: set the GHCR package to **public** so the host pulls anonymously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)