### PR TITLE
fix(docker): install Yarn 1 (node:26-alpine dropped bundled yarn)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,15 @@
 # ---- deps: install dependencies (cached on lockfile) ----
 FROM node:26-alpine AS deps
 WORKDIR /app
+# node:26-alpine no longer bundles yarn — install Yarn 1 (classic) for the yarn.lock
+RUN npm install -g yarn@1.22.22
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
 # ---- builder: standalone Next.js build ----
 FROM node:26-alpine AS builder
 WORKDIR /app
+RUN npm install -g yarn@1.22.22
 ARG GIT_SHA=dev
 # BUILD_STANDALONE=1 makes next.config emit output:'standalone' (Netlify stays default).
 ENV BUILD_STANDALONE=1 \


### PR DESCRIPTION
## Problem

The first GHCR build on `main` (after #610) failed at the `deps` stage:

```
#14 0.050 /bin/sh: yarn: not found
```

(exit 127). `node:26-alpine` no longer ships a bundled `yarn`, so `RUN yarn install --frozen-lockfile` had no `yarn` on PATH.

## Fix

Install Yarn 1 (classic) explicitly in both stages that invoke it:

- `deps` stage — before `yarn install --frozen-lockfile`
- `builder` stage — before `yarn build`

```dockerfile
RUN npm install -g yarn@1.22.22
```

Pinned to `1.22.22` (matches the `yarn.lock` format). No change to the `runner` stage — it only runs `node server.js`.

## After merge

The build re-triggers on `main`, publishes `ghcr.io/bjornwiberg/astro-events:latest`, and the pull-agent on the PVE picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)