### PR TITLE
fix(docker): pass --ignore-engines to yarn install (node 26)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ WORKDIR /app
 # node:26-alpine no longer bundles yarn — install Yarn 1 (classic) for the yarn.lock
 RUN npm install -g yarn@1.22.22
 COPY package.json yarn.lock ./
-RUN yarn install --frozen-lockfile
+# --ignore-engines: mixpanel-browser pins engines to "node >=20 <26"; it's a browser
+# lib and runs fine on node 26. Without this, yarn classic aborts the frozen install.
+RUN yarn install --frozen-lockfile --ignore-engines
 
 # ---- builder: standalone Next.js build ----
 FROM node:26-alpine AS builder


### PR DESCRIPTION
## Problem

The `Build & publish astro image` job fails at the `deps` stage:

```
error mixpanel-browser@2.80.0: The engine "node" is incompatible with this module. Expected version ">=20 <26". Got "26.3.0"
error Found incompatible module.
```

After moving the base image to `node:26-alpine` (#613), `yarn install --frozen-lockfile` aborts because `mixpanel-browser` pins `engines: node >=20 <26`. Even the latest `mixpanel-browser` keeps this upper bound. This also cascades to the `e2e` job (depends on the build), failing the overall CI status check.

## Fix

Pass `--ignore-engines` to the deps install. `mixpanel-browser` is a browser library — the node engine bound only refers to the build/install toolchain and is overly conservative. It runs fine on node 26.

## Verified locally

- ✅ `docker build --target deps`: `yarn install` completes
- ✅ `docker build` (full image): `yarn build` standalone succeeds, runner image written
- ✅ Installed `mixpanel-browser` is still **2.80.0** in the built image — analytics unchanged, version not bumped (`--frozen-lockfile` retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)