### PR TITLE
ci(deploy): GHCR registry build cache instead of GHA cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,12 @@ jobs:
           tags: |
             ${{ env.IMAGE }}:latest
             ${{ env.IMAGE }}:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Registry cache (co-located with the image on GHCR) instead of the GHA
+          # cache backend: gha,mode=max stalled the job ~2min on cache export for the
+          # large node_modules layers. Registry export piggybacks on the push and is
+          # far faster, while still caching the multi-stage deps layer (mode=max).
+          cache-from: type=registry,ref=${{ env.IMAGE }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max
 
   # NO deploy job here — deploy is decoupled for maximum security on a public repo:
   # a pull-agent on LXC 106 (systemd timer) watches GHCR and runs


### PR DESCRIPTION
## Problem

The `Build & publish astro image` job stalls ~2 min **after** the image is already pushed, on the cache-export step:

```
#22 pushing manifest ... DONE 9.4s
#24 preparing build cache for export 124.8s done
#24 writing layer ... 22.2s done   (×many)
```

`cache-to: type=gha,mode=max` exports every intermediate layer (incl. the big node_modules layers) to the GitHub Actions cache backend, which is slow and rate-limited.

## Fix

Switch the build cache from the GHA backend to **registry cache on GHCR** (where the image is already pushed). The export piggybacks on the push and is far faster, while `mode=max` still caches the multi-stage `deps` layer so `yarn install` stays skipped on unchanged lockfiles.

Note: the first run after merge is still cold (no `:buildcache` tag yet); the speedup lands from the second build onward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)