### PR TITLE
fix: calculator API array module flags + hide internal config in error

### DIFF
--- a/lib/calculator.ts
+++ b/lib/calculator.ts
@@ -48,9 +48,9 @@ export async function fetchCalculatorEventsByRange(
       tmb,
       tmf,
       modules: {
-        eclipse: true,
-        season: true,
-        mphase: true,
+        eclipse: [],
+        season: [],
+        mphase: [],
       },
     }),
     next: { revalidate: CACHE_REVALIDATE_SECONDS },

--- a/locales/en.json
+++ b/locales/en.json
@@ -77,7 +77,7 @@
   },
   "errors": {
     "fetchEvents": "Error fetching events",
-    "fetchEventsHint": "Set CALCULATOR_API_URL and CALCULATOR_API_KEY in .env.local"
+    "fetchEventsHint": "Please try again later."
   },
   "loading": {
     "changingLanguage": "Changing language…"


### PR DESCRIPTION
## What

Two fixes prompted by a production error and a UI leak.

### 1. Calculator API breaking change (400 Bad Request)
The calculator API now rejects boolean module flags. Probing the live API confirmed it accepts only array values for **all** modules — not just `mphase`. `eclipse: true` and `season: true` were still triggering the 400.

```diff
 modules: {
-  eclipse: true,
-  season: true,
-  mphase: true,
+  eclipse: [],
+  season: [],
+  mphase: [],
 },
```

Verified against the live API: `200 OK`, returns `mphase`, `eclipse`, and `season`/`simple` events as before.

### 2. Internal config leaked in the UI
The error hint shown to end users read `Set CALCULATOR_API_URL and CALCULATOR_API_KEY in .env.local`, exposing internal env var names and a filename. Replaced `errors.fetchEventsHint` in `locales/en.json` with a generic "Please try again later." (LibreTranslate regenerates the other languages on source-hash change).

## Files
- `lib/calculator.ts`
- `locales/en.json`