### PR TITLE
fix(v2): show location results with localized/diacritic names

### DIFF
--- a/app/v2/components/LocationSelector.tsx
+++ b/app/v2/components/LocationSelector.tsx
@@ -209,6 +209,11 @@ export function LocationSelector({ value, onChange }: LocationSelectorProps) {
           else setInputValue(v);
         }}
         options={options}
+        // Results are already filtered server-side by the geocode query. Disable
+        // MUI's default client-side filtering, which substring-matches the input
+        // against the label and would drop localized/diacritic names (e.g. typing
+        // "bucharest" hides "București, România"), leaving an empty dropdown.
+        filterOptions={(opts) => opts}
         getOptionLabel={(opt) => (typeof opt === "string" ? opt : opt.display_name)}
         loading={loading}
         onFocus={handleFocus}

--- a/tests/v2/location-search.spec.ts
+++ b/tests/v2/location-search.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+import { mockV2ClientEndpoints, seedLocationCookie, seedSeenTours } from "./helpers";
+
+const INTRO_STEPS = ["welcome", "theme", "language", "calendar", "location", "navigation", "events"];
+
+test.describe("location search", () => {
+  test.beforeEach(async ({ context, page }) => {
+    await seedSeenTours(context, { intro: INTRO_STEPS });
+    await seedLocationCookie(context);
+    await mockV2ClientEndpoints(page);
+
+    // Override geocode so the resolved display_name does NOT substring-match the
+    // typed query (localized name + diacritics) — e.g. "bucharest" → "București".
+    await page.route("**/api/v2/geocode**", async (route) => {
+      const url = new URL(route.request().url());
+      const action = url.searchParams.get("action");
+      if (action === "search") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            {
+              display_name: "București, România",
+              lat: "44.4361",
+              lon: "26.1027",
+              address: { city: "București", country: "România" },
+            },
+          ]),
+        });
+        return;
+      }
+      if (action === "reverse") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            display_name: "București, România",
+            address: { city: "București", country: "România" },
+            timezone: "Europe/Bucharest",
+          }),
+        });
+        return;
+      }
+      await route.fulfill({ status: 400, body: "{}" });
+    });
+  });
+
+  test("shows a result even when its localized name does not match the typed query", async ({
+    page,
+  }) => {
+    await page.goto("/v2");
+
+    const input = page.locator("#v2-location-selector");
+    await input.click();
+    await input.press("ControlOrMeta+a");
+    await input.press("Backspace");
+    await input.focus();
+    // Single input event — avoids the controlled-input char-drop race that
+    // per-character typing hits with React-controlled MUI inputs.
+    await page.keyboard.insertText("bucharest");
+
+    // Before the fix, MUI's default filterOptions removes "București, România"
+    // because it doesn't contain the substring "bucharest" → empty dropdown.
+    const option = page.getByRole("option", { name: /Bucure/i });
+    await expect(option).toBeVisible();
+
+    await option.click();
+    // After selecting, the input reflects the resolved place, not the raw query.
+    await expect(input).toHaveValue(/Bucure/i);
+  });
+});


### PR DESCRIPTION
## Bug

Searching for a place whose resolved name differs from what you type returns nothing selectable. E.g. typing **"bucharest"** — the geocode API returns `display_name: "București, România"`, but the dropdown stays empty and the input keeps showing the raw typed text. You can never pick the place.

## Root cause

`LocationSelector` fetches results **server-side** per query, but MUI `Autocomplete` then runs its **default client-side `filterOptions`** on top — a substring match of the input against each option's label (`display_name`). `"bucharest"` does not substring-match `"București, România"` (diacritics `ș`/`ă` + localized name), so the only result is filtered out → dropdown never opens → nothing to select.

Verified against the live dev server with Playwright:

| query | dropdown | options |
|---|---|---|
| `london` | open | 3 (labels contain "london") |
| `bucharest` | **closed** | **0** (server returned "București, România") |

## Fix

Disable MUI's client-side filtering with `filterOptions={(x) => x}` — the geocode endpoint already filters by the query, so the second pass only does harm. The canonical MUI pattern for server-side/async search.

After the fix, `bucharest` shows `București, România`, it's selectable, and the input then reflects the resolved location (`București`) instead of the raw query.

## Test

`tests/v2/location-search.spec.ts` mocks a geocode result whose localized name doesn't match the typed query and asserts the option appears and is selectable — fails before the fix, passes after.

## Scope

v2 only. Independent of #620 (Maha Shivaratri).

🤖 Generated with [Claude Code](https://claude.com/claude-code)